### PR TITLE
Fix BGIDemo

### DIFF
--- a/examples/bgidemo/BgiDemo_Form.pas
+++ b/examples/bgidemo/BgiDemo_Form.pas
@@ -68,6 +68,7 @@ begin
     Exit;
   end;
 
+  BorlandPaintBox.Invalidate;
   InitGraph(BorlandPaintBox.Canvas, BorlandPaintbox.Width, BorlandPaintbox.Height);
   Initialize;
   SetGothicFont('Old English Text MT', [10, 12, 14, 16, 20, 24, 28, 32, 38, 48, 72], []);
@@ -159,6 +160,7 @@ end;
 
 procedure TMainForm.OwnPaintboxPaint(Sender: TObject);
 begin
+  OwnPaintBox.Invalidate;
   InitGraph(OwnPaintBox.Canvas, OwnPaintBox.Width, OwnPaintBox.Height);
   Initialize;
   case OwnDemoList.ItemIndex of


### PR DESCRIPTION
When running the demo, nothing changes unless the window is invalidated.

According to the documentation, painting has to happen when the canvas is invalidated, adding this to the demo fixed the issue.